### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,5 @@ For more `params` pattern, see [offical doc](https://www.kairos.com/docs/face-re
 ## LICENSE
 
 [MIT](LICENSE)
+
+Test on [RapidAPI](https://rapidapi.com/package/KairosAPI/functions?utm_source=KairosGitHub&utm_medium=button)


### PR DESCRIPTION
I've added a link in your README to Kairos's functions page in RapidAPI. I've done this for a few Kairos SDKs to help those who are reading the READMEs, understand and test the API before use.